### PR TITLE
fix undefined pointer when enabling auditLogScope

### DIFF
--- a/models/audit-log.model.js
+++ b/models/audit-log.model.js
@@ -110,7 +110,9 @@ module.exports = function(mongoose) {
   }
 
   if (!_.isEmpty(Config.auditLogScope)) {
-    Schema.statics.routeOptions.routeScope.rootScope = Config.auditLogScope
+    Schema.statics.routeOptions.routeScope = {
+      rootScope: Config.auditLogScope
+    }
   }
 
   return Schema


### PR DESCRIPTION
```
/node_modules/rest-hapi/models/audit-log.model.js:113
    Schema.statics.routeOptions.routeScope.rootScope = Config.auditLogScope
                                                     ^
TypeError: Cannot set property 'rootScope' of undefined
```